### PR TITLE
Fix issue loading gravatar template tag.

### DIFF
--- a/wagtail_comments_xtd/templates/wagtail_comments_xtd/comments/_list_explore.html
+++ b/wagtail_comments_xtd/templates/wagtail_comments_xtd/comments/_list_explore.html
@@ -1,11 +1,11 @@
 {% load i18n %}
-{% load gravatar %}
+{% load comments_xtd %}
 
 <tbody>
 	{% for element in comments %}
 		<tr class="">
 			<td class="ord">
-				<span class="avatar icon icon-user" style="top:0;"><img src="{% gravatar_url element.comment.user_email %}" /></span>
+				<span class="avatar icon icon-user" style="top:0;"><img src="{{ element.comment.user_email|xtd_comment_gravatar_url  }}" /></span>
 			</td>
 			<td class="title" valign="top" data-listing-page-title="">
 				<h2>


### PR DESCRIPTION
Hi,

My install of Wagtail (2.5.1) cannot is unable to load the list view for comments in the admin. 

I noticed that the `gravatar` tag is unavailable. 

I've amended admin list explore template to use django-comment-xtd's `xtd_comment_gravatar_url` filter to output gravatar profile image of commenter.

https://django-comments-xtd.readthedocs.io/en/latest/templatetags.html#filter-xtd-comment-gravatar-url